### PR TITLE
Fix LIT and LUGA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # LIT 2016
 
 Here you can find the (German) slides for my presentation of (tiling) window
-managers and i3wm on the Linux Infotag 2016 organized by the Linux Info
-Usergroup Augsburg.
+managers and i3wm on the Augsburger Linux-Infotag 2016 (http://www.luga.de/Aktionen/LIT-2016/)
+organized by the Linux User Group Augsburg (luga).
 
 The slides are in markdown format and written to be used with mdp, a terminal
 interface presentation software.


### PR DESCRIPTION
The organizer ist the Linux User Group Augsburg (luga), the even is the Augsburger Linux-Infotag.
